### PR TITLE
docs: add Kenney asset package map

### DIFF
--- a/docs/ASSET_MANIFEST.md
+++ b/docs/ASSET_MANIFEST.md
@@ -2,6 +2,20 @@
 
 Tracks curated assets that are selected from the Kenney bundle and imported or prepared for MakeCode Arcade.
 
+Use `docs/KENNEY_ASSET_MAP.md` to choose source package folders and destination folders. This manifest is updated when concrete files are copied into `assets/selected/kenney/` and/or imported into MakeCode assets.
+
+## Batch 1 target manifest (to be filled with concrete filenames after local copy)
+
+| Asset ID | Type | Source Pack / Folder | Repo File | Used In | Imported Into MakeCode | Notes |
+|---|---|---|---|---|---|---|
+| SPR_PLAYER_TOPDOWN | sprite | `2D assets/Roguelike Characters Pack` or `2D assets/Character Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Hub player | no | Pick one small readable top-down character. |
+| SPR_DOOR_DUNGEON | sprite/tile | `2D assets/RPG Urban Pack` or `2D assets/Roguelike City Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Hub dungeon doors | no | Needs to be clearly visible in hub. |
+| SPR_NPC_SAVEHOUSE | sprite | `2D assets/Roguelike Characters Pack` or `2D assets/Character Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Savehouse NPC | no | Use friendly/non-threatening character. |
+| SPR_INPUT_A | icon | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/<file>.png` | Interact prompt | no | Rename `×` to `x` in repo path. |
+| TM_HUB_11 | tilemap | `2D assets/RPG Urban Pack` + `2D assets/Roguelike City Pack` | MakeCode Asset Editor / tilemap asset | Hub start room | no | Build from curated tiles after palette test. |
+
+## Full manifest
+
 | Asset ID | Type | Source Pack / Folder | Repo File | Used In | Imported Into MakeCode | Notes |
 |---|---|---|---|---|---|---|
 | TBD | TBD | Kenney All-in-1 | TBD | TBD | no | Fill this table per asset batch. |

--- a/docs/ASSET_MANIFEST.md
+++ b/docs/ASSET_MANIFEST.md
@@ -2,7 +2,7 @@
 
 Tracks curated assets that are selected from the Kenney bundle and imported or prepared for MakeCode Arcade.
 
-Use `docs/KENNEY_ASSET_MAP.md` to choose source package folders and destination folders. This manifest is updated when concrete files are copied into `assets/selected/kenney/` and/or imported into MakeCode assets.
+Use `docs/KENNEY_ASSET_MAP.md` to choose source package folders and destination folders. Use `.github/ASSET_REQUIREMENTS.md` for canonical asset IDs. This manifest is updated when concrete files are copied into `assets/selected/kenney/` and/or imported into MakeCode assets.
 
 ## Batch 1 target manifest (to be filled with concrete filenames after local copy)
 
@@ -11,7 +11,7 @@ Use `docs/KENNEY_ASSET_MAP.md` to choose source package folders and destination 
 | SPR_PLAYER_TOPDOWN | sprite | `2D assets/Roguelike Characters Pack` or `2D assets/Character Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Hub player | no | Pick one small readable top-down character. |
 | SPR_DOOR_DUNGEON | sprite/tile | `2D assets/RPG Urban Pack` or `2D assets/Roguelike City Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Hub dungeon doors | no | Needs to be clearly visible in hub. |
 | SPR_NPC_SAVEHOUSE | sprite | `2D assets/Roguelike Characters Pack` or `2D assets/Character Pack` | `assets/selected/kenney/hub/<source-package>/<file>.png` | Savehouse NPC | no | Use friendly/non-threatening character. |
-| SPR_INPUT_A | icon | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/<file>.png` | Interact prompt | no | Rename `×` to `x` in repo path. |
+| SPR_INTERACT_PROMPT | icon | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/<file>.png` | Interact prompt | no | Canonical prompt ID from `.github/ASSET_REQUIREMENTS.md`; repo path normalizes `×` to `x`. |
 | TM_HUB_11 | tilemap | `2D assets/RPG Urban Pack` + `2D assets/Roguelike City Pack` | MakeCode Asset Editor / tilemap asset | Hub start room | no | Build from curated tiles after palette test. |
 
 ## Full manifest

--- a/docs/ASSET_PIPELINE.md
+++ b/docs/ASSET_PIPELINE.md
@@ -9,6 +9,7 @@ Workflow for selecting and integrating Kenney assets into NeonKiez.
 - Test palette mapping before importing large subsets.
 - Keep asset IDs stable; replace asset contents rather than changing code references.
 - Use `docs/KENNEY_ASSET_MAP.md` as the source-of-truth for package-folder-to-repo-folder mapping.
+- Use `.github/ASSET_REQUIREMENTS.md` as the source-of-truth for canonical asset IDs.
 
 ## Directory map
 
@@ -19,11 +20,23 @@ Workflow for selecting and integrating Kenney assets into NeonKiez.
 - `docs/ASSET_MANIFEST.md`: selected asset inventory.
 - `docs/KENNEY_ASSET_MAP.md`: exact Kenney package-folder mapping and first import batches.
 
+## Path normalization
+
+When a Kenney source folder contains characters that are awkward in repo paths, use the exact normalized destination shown in `docs/KENNEY_ASSET_MAP.md`.
+
+Examples:
+
+- `Input Prompts Pixel 16×` -> `Input Prompts Pixel 16x`
+- `Road Textures (Classic)` -> `Road Textures Classic`
+- `Extra Animations & Enemies` -> `Extra Animations and Enemies`
+
+Do not infer new normalized names. Use the exact target path from the map.
+
 ## Batch workflow
 
 1. Open `docs/KENNEY_ASSET_MAP.md` and choose the next batch.
-2. Copy only the required files from the listed Kenney package folders into the listed `assets/selected/kenney/<area>/<Package Name>/` target.
-3. Update `docs/ASSET_MANIFEST.md` with the selected files and expected MakeCode asset IDs.
+2. Copy only the required files from the listed Kenney package folders into the exact target path shown in the map, e.g. `assets/selected/kenney/<area>/<Package Name or normalized package name>/`.
+3. Update `docs/ASSET_MANIFEST.md` with the selected files and canonical asset IDs from `.github/ASSET_REQUIREMENTS.md`.
 4. Import/adapt the subset into MakeCode assets.
 5. Update factories in `assets_stub.ts` or the relevant asset wrapper.
 6. Run a manual smoke test.
@@ -39,4 +52,4 @@ Start with Batch 1 from `docs/KENNEY_ASSET_MAP.md`:
 - `Icons/Input Prompts Pixel 16×` -> `assets/selected/kenney/ui/Input Prompts Pixel 16x/`
 - `UI assets/UI Pixel Pack` -> `assets/selected/kenney/ui/UI Pixel Pack/`
 
-Goal: `SPR_PLAYER_TOPDOWN`, `SPR_DOOR_DUNGEON`, `SPR_NPC_SAVEHOUSE`, `TM_HUB_11`, and one visible A-button prompt.
+Goal: `SPR_PLAYER_TOPDOWN`, `SPR_DOOR_DUNGEON`, `SPR_NPC_SAVEHOUSE`, `SPR_INTERACT_PROMPT`, `TM_HUB_11`.

--- a/docs/ASSET_PIPELINE.md
+++ b/docs/ASSET_PIPELINE.md
@@ -8,6 +8,7 @@ Workflow for selecting and integrating Kenney assets into NeonKiez.
 - Use 16x16 assets where possible for MakeCode Arcade.
 - Test palette mapping before importing large subsets.
 - Keep asset IDs stable; replace asset contents rather than changing code references.
+- Use `docs/KENNEY_ASSET_MAP.md` as the source-of-truth for package-folder-to-repo-folder mapping.
 
 ## Directory map
 
@@ -16,13 +17,26 @@ Workflow for selecting and integrating Kenney assets into NeonKiez.
 - `assets/working/`: temporary resized, palette-test, or spritesheet files.
 - `docs/ASSET_SOURCES.md`: source and license tracking.
 - `docs/ASSET_MANIFEST.md`: selected asset inventory.
+- `docs/KENNEY_ASSET_MAP.md`: exact Kenney package-folder mapping and first import batches.
 
 ## Batch workflow
 
-1. Pick one small batch, e.g. Hub base tiles, Platform sprites, or Asteroids sprites.
-2. Copy only the required files into `assets/selected/kenney/<area>/`.
-3. Update `docs/ASSET_MANIFEST.md`.
+1. Open `docs/KENNEY_ASSET_MAP.md` and choose the next batch.
+2. Copy only the required files from the listed Kenney package folders into the listed `assets/selected/kenney/<area>/<Package Name>/` target.
+3. Update `docs/ASSET_MANIFEST.md` with the selected files and expected MakeCode asset IDs.
 4. Import/adapt the subset into MakeCode assets.
 5. Update factories in `assets_stub.ts` or the relevant asset wrapper.
 6. Run a manual smoke test.
 7. Document test evidence in the PR.
+
+## First recommended batch
+
+Start with Batch 1 from `docs/KENNEY_ASSET_MAP.md`:
+
+- `2D assets/RPG Urban Pack` -> `assets/selected/kenney/hub/RPG Urban Pack/`
+- `2D assets/Roguelike City Pack` -> `assets/selected/kenney/hub/Roguelike City Pack/`
+- `2D assets/Roguelike Characters Pack` -> `assets/selected/kenney/hub/Roguelike Characters Pack/`
+- `Icons/Input Prompts Pixel 16×` -> `assets/selected/kenney/ui/Input Prompts Pixel 16x/`
+- `UI assets/UI Pixel Pack` -> `assets/selected/kenney/ui/UI Pixel Pack/`
+
+Goal: `SPR_PLAYER_TOPDOWN`, `SPR_DOOR_DUNGEON`, `SPR_NPC_SAVEHOUSE`, `TM_HUB_11`, and one visible A-button prompt.

--- a/docs/KENNEY_ASSET_MAP.md
+++ b/docs/KENNEY_ASSET_MAP.md
@@ -2,30 +2,31 @@
 
 Mapping from the purchased Kenney All-in-1 package overview to NeonKiez repo folders.
 
-Source overview: `ce7c6a16-4e5d-456b-a986-4e1cfbabeafd.html` (Kenney Game Assets All-in-1 package index). The overview lists 239 packages across 2D, 3D, Audio, Icons, UI, and Other categories. It provides package folder paths, not individual PNG/WAV filenames. Therefore this document maps **Kenney package folders** to repo folders and expected MakeCode asset IDs. Exact file-level selection happens after the bundle is unpacked locally.
+Canonical asset IDs come from `.github/ASSET_REQUIREMENTS.md`. This document must not introduce parallel asset naming schemes.
 
 ## Important rules
 
 - Use only Kenney All-in-1 assets unless the project owner explicitly approves another source.
 - Do not commit the full purchased archive.
 - Copy only curated subsets into `assets/selected/kenney/`.
-- Keep original package names in subfolders when copying files, so provenance stays obvious.
 - Prefer 2D, pixel, UI, icon, and audio packs. Avoid 3D packs for v1.0.
 - MakeCode Arcade target: 16x16 tiles where possible, small sprite sets, limited palette, no giant sheets.
 
-## Recommended subfolder pattern
+## Package name normalization
 
-When copying a curated subset, preserve the package name below the target area:
+The `Source package path in Kenney bundle` column always uses the original Kenney folder name. The `Copy to repo folder` column is the exact repo target and may use a filesystem-safe normalized folder name.
+
+Normalization is allowed only when explicitly shown in this table:
+
+- Replace the Unicode multiplication sign `×` with ASCII `x`.
+- Remove parentheses only when the target path explicitly shows the normalized variant.
+- Replace `&` with `and` only when the target path explicitly shows the normalized variant.
+- Never infer a normalized path. Use the exact `Copy to repo folder` value.
+
+Recommended pattern:
 
 ```text
-assets/selected/kenney/<area>/<Kenney Package Name>/...
-```
-
-Example:
-
-```text
-assets/selected/kenney/hub/RPG Urban Pack/...
-assets/selected/kenney/modes/asteroids/Space Shooter Redux/...
+assets/selected/kenney/<area>/<Package Name or normalized package name>/...
 ```
 
 ## Priority legend
@@ -45,27 +46,33 @@ Target folder: `assets/selected/kenney/hub/`
 |---|---|---|---|---|
 | P0 | `2D assets/RPG Urban Pack` | `assets/selected/kenney/hub/RPG Urban Pack/` | Hub streets, sidewalks, buildings, doors, city props | Primary hub pack. Use as first source for `TM_HUB_00..22`. |
 | P0 | `2D assets/Roguelike City Pack` | `assets/selected/kenney/hub/Roguelike City Pack/` | Compact city tiles, urban props | Good fallback for MakeCode-friendly small tiles. |
-| P1 | `2D assets/Tiny Town` | `assets/selected/kenney/hub/Tiny Town/` | Simplified city props / readable fallback tiles | Use only if style fits after palette test. |
-| P1 | `2D assets/Pico-8 City` | `assets/selected/kenney/hub/Pico-8 City/` | Low-color city look, palette-friendly props | Candidate for MakeCode palette compatibility. |
 | P1 | `2D assets/Character Pack` | `assets/selected/kenney/hub/Character Pack/` | Hub NPCs / civilian silhouettes | Select only small readable characters. |
 | P1 | `2D assets/Character Pack Redux` | `assets/selected/kenney/hub/Character Pack Redux/` | Hub NPC variants | Alternative to Character Pack. |
 | P1 | `2D assets/Roguelike Characters Pack` | `assets/selected/kenney/hub/Roguelike Characters Pack/` | Top-down NPCs / player placeholder | Prefer if sprites are small and readable. |
 | P1 | `2D assets/Robot Pack` | `assets/selected/kenney/hub/Robot Pack/` | Friendly bots, comic blockers, dungeon bots | Good for child-friendly non-human enemies. |
 | P1 | `2D assets/Generic Items` | `assets/selected/kenney/hub/Generic Items/` | Collectibles, savehouse props, inventory objects | Use for small props/items. |
 | P2 | `2D assets/Emote Pack` | `assets/selected/kenney/hub/Emote Pack/` | NPC feedback bubbles | Optional UX polish. |
-| P2 | `2D assets/Googly Eyes` | `assets/selected/kenney/hub/Googly Eyes/` | Comic prop accents | Optional, use sparingly. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs from `.github/ASSET_REQUIREMENTS.md`:
 
 - `SPR_PLAYER_TOPDOWN`
+- `ANIM_PLAYER_TOPDOWN_WALK`
 - `SPR_NPC_GENERIC_01..03`
 - `SPR_NPC_SAVEHOUSE`
+- `ANIM_NPC_IDLE`
 - `SPR_DOOR_DUNGEON`
 - `SPR_DOOR_FINAL`
-- `T_HUB_FLOOR_*`
-- `T_HUB_WALL_*`
-- `T_HUB_ROAD_*`
-- `T_HUB_PROP_*`
+- `SPR_INTERACT_PROMPT`
+- `T_HUB_FLOOR_01..03`
+- `T_HUB_WALL_01..03`
+- `T_HUB_EDGE` / `T_HUB_BORDER`
+- `T_HUB_SIGN_01..06`
+- `T_HUB_PROP_01..10`
+- `T_HUB_DECAL_01..06`
+- `T_MARK_SPAWN_<TAG>`
+- `T_MARK_DOOR_<DUN_ID>`
+- `T_MARK_EXIT`
+- `T_MARK_NPC_<ID>`
 - `TM_HUB_00..22`
 
 ---
@@ -80,16 +87,12 @@ Target folder: `assets/selected/kenney/overworld/`
 | P1 | `2D assets/Foliage Pack` | `assets/selected/kenney/overworld/Foliage Pack/` | Trees, bushes, outdoor props | Select small readable objects only. |
 | P1 | `2D assets/Foliage Sprites` | `assets/selected/kenney/overworld/Foliage Sprites/` | Outdoor sprite props | Alternative/extension to Foliage Pack. |
 | P1 | `2D assets/Road Textures` | `assets/selected/kenney/overworld/Road Textures/` | Roads / asphalt / pavement | Check tile size and palette first. |
-| P1 | `2D assets/Road Textures (Classic)` | `assets/selected/kenney/overworld/Road Textures Classic/` | Classic road texture fallback | Use if more retro-readable. |
+| P1 | `2D assets/Road Textures (Classic)` | `assets/selected/kenney/overworld/Road Textures Classic/` | Classic road texture fallback | Normalized repo folder removes parentheses. |
 | P2 | `2D assets/Cartography Pack` | `assets/selected/kenney/overworld/Cartography Pack/` | Map/minimap style graphics | Optional; not core gameplay. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
-- `T_OVERWORLD_GRASS_*`
-- `T_OVERWORLD_PATH_*`
-- `T_OVERWORLD_ROAD_*`
-- `T_OVERWORLD_TREE_*`
-- `TM_OVERWORLD_01..02` (only if used)
+- `TM_OVERWORLD_01..02` if used.
 
 ---
 
@@ -99,33 +102,28 @@ Target folder: `assets/selected/kenney/ui/`
 
 | Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
 |---|---|---|---|---|
-| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/` | A/B/Menu prompts, tutorial hints | Primary input prompt source. Rename `×` to `x` in repo path for filesystem simplicity. |
+| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/` | Interact prompt, tutorial hints | Normalized repo folder replaces `×` with `x`. |
 | P0 | `UI assets/UI Pixel Pack` | `assets/selected/kenney/ui/UI Pixel Pack/` | HUD frames, small UI panels, buttons | Primary pixel UI pack. |
 | P0 | `Icons/Game Icons` | `assets/selected/kenney/ui/Game Icons/` | Tool icons, inventory icons, reward icons | Primary icon source. |
 | P1 | `Icons/Game Icons Expansion` | `assets/selected/kenney/ui/Game Icons Expansion/` | Additional icons | Use only if base Game Icons is insufficient. |
 | P1 | `UI assets/Cursor Pixel Pack` | `assets/selected/kenney/ui/Cursor Pixel Pack/` | Menu cursor / selector | Pixel-friendly. |
 | P1 | `2D assets/Development Essentials` | `assets/selected/kenney/ui/Development Essentials/` | Debug markers, simple placeholders | Good for development-only visuals. |
-| P1 | `Icons/1-Bit Input Prompts Pixel 16×` | `assets/selected/kenney/ui/1-Bit Input Prompts Pixel 16x/` | Minimal input prompts fallback | Use if low-color UI is desired. |
+| P1 | `Icons/1-Bit Input Prompts Pixel 16×` | `assets/selected/kenney/ui/1-Bit Input Prompts Pixel 16x/` | Minimal input prompt fallback | Normalized repo folder replaces `×` with `x`. |
 | P2 | `UI assets/UI Pack - Sci-fi` | `assets/selected/kenney/ui/UI Pack - Sci-fi/` | Neon/glitch menu accents | Optional polish; verify style/palette. |
 | P2 | `UI assets/UI Pack` | `assets/selected/kenney/ui/UI Pack/` | Generic UI fallback | Use sparingly. |
 | P2 | `UI assets/UI Pack - Pixel Adventure` | `assets/selected/kenney/ui/UI Pack - Pixel Adventure/` | Pixel menu fallback | Optional. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
-- `SPR_UI_HEART_FULL`
-- `SPR_UI_HEART_EMPTY`
-- `SPR_UI_TOOL_FREEZECAM`
-- `SPR_UI_TOOL_CONFETTI`
-- `SPR_UI_TOOL_SOAP`
-- `SPR_UI_TOOL_DECOY`
-- `SPR_UI_TOOL_TAGGER`
-- `SPR_UI_CURSOR`
-- `SPR_INPUT_A`
-- `SPR_INPUT_B`
-- `SPR_INPUT_MENU`
+- `SPR_UI_HEART`
+- `SPR_UI_TOOL_ICON_<TOOL_ID>`
+- `SPR_UI_CURSOR` / `SPR_UI_SELECTOR`
+- `SPR_UI_DIALOG_FRAME`
+- `SPR_UI_POPUP_ICON_INFO` / `WARN` / `OK`
+- `SPR_INTERACT_PROMPT`
 - `SPR_RHYTHM_BEAT_INDICATOR`
-- `SPR_RHYTHM_GOOD`
-- `SPR_RHYTHM_MISS`
+- `SPR_RHYTHM_WINDOW_GOOD` / `OK` / `MISS`
+- `SPR_RHYTHM_TRACK_MARKERS`
 
 ---
 
@@ -140,24 +138,28 @@ Target folder: `assets/selected/kenney/modes/platform/`
 | P0 | `2D assets/Pixel Platformer Industrial Expansion` | `assets/selected/kenney/modes/platform/Pixel Platformer Industrial Expansion/` | Construction / warehouse / industrial tiles | Primary D08 construction source. |
 | P1 | `2D assets/Platformer Pack Industrial` | `assets/selected/kenney/modes/platform/Platformer Pack Industrial/` | Girders, ladders, industrial props | D08 Donkey Tower candidate. |
 | P1 | `2D assets/Platformer Assets Pixel` | `assets/selected/kenney/modes/platform/Platformer Assets Pixel/` | Pixel platform tiles | Alternative to Pixel Platformer. |
-| P1 | `2D assets/Platformer Assets Extra Animations & Enemies` | `assets/selected/kenney/modes/platform/Platformer Assets Extra Animations and Enemies/` | Extra enemy animations | Use sparingly; avoid animation bloat. |
+| P1 | `2D assets/Platformer Assets Extra Animations & Enemies` | `assets/selected/kenney/modes/platform/Platformer Assets Extra Animations and Enemies/` | Extra enemy animations | Normalized repo folder replaces `&` with `and`; use sparingly. |
 | P1 | `2D assets/Pixel Platformer Blocks` | `assets/selected/kenney/modes/platform/Pixel Platformer Blocks/` | Platforms / blocks / stage geometry | Good for simple geometry. |
 | P2 | `2D assets/1-Bit Platformer Pack` | `assets/selected/kenney/modes/platform/1-Bit Platformer Pack/` | Low-color fallback | Only if style direction changes. |
 | P2 | `2D assets/Pico-8 Platformer` | `assets/selected/kenney/modes/platform/Pico-8 Platformer/` | Palette-friendly fallback | Optional. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
 - `SPR_PLAT_PLAYER`
-- `ANIM_PLAT_PLAYER_WALK`
+- `ANIM_PLAT_WALK`
 - `SPR_PLAT_ENEMY_01..02`
 - `SPR_PLAT_COLLECTIBLE`
+- `T_PLAT_GROUND_01..02`
+- `T_PLAT_PLATFORM_01..02`
+- `T_PLAT_LADDER`
+- `T_PLAT_HAZARD_01`
+- `T_PLAT_GOAL`
+- `SPR_DONKEY_PLAYER`
 - `SPR_DONKEY_BARREL`
-- `SPR_DONKEY_FOREMAN_BOT`
-- `T_PLAT_GROUND_*`
-- `T_PLAT_PLATFORM_*`
-- `T_PLAT_HAZARD_*`
-- `T_DONKEY_GIRDER_*`
+- `SPR_DONKEY_BOSS`
+- `T_DONKEY_GIRDER_01..02`
 - `T_DONKEY_LADDER`
+- `T_DONKEY_HAZARD`
 - `TM_D07_STAGE_00..03`
 - `TM_D08_STAGE_00..03`
 
@@ -169,19 +171,20 @@ Target folder: `assets/selected/kenney/modes/shooter/`
 
 | Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
 |---|---|---|---|---|
-| P0 | `2D assets/Topdown Shooter (Pixel)` | `assets/selected/kenney/modes/shooter/Topdown Shooter Pixel/` | Player ship, enemies, bullets | Primary shooter source for MakeCode-friendly pixel style. |
+| P0 | `2D assets/Topdown Shooter (Pixel)` | `assets/selected/kenney/modes/shooter/Topdown Shooter Pixel/` | Player ship, enemies, bullets | Normalized repo folder removes parentheses. |
 | P1 | `2D assets/Topdown Shooter` | `assets/selected/kenney/modes/shooter/Topdown Shooter/` | Higher-res source/fallback | Use only selected small sprites if palette/size works. |
 | P1 | `2D assets/Pixel Shmup` | `assets/selected/kenney/modes/shooter/Pixel Shmup/` | Invader-like enemies, bullets, powerups | Good for classic arcade feel. |
 | P1 | `2D assets/Space Shooter Redux` | `assets/selected/kenney/modes/shooter/Space Shooter Redux/` | Enemy formations / projectiles / core | Can be shared with asteroids. |
 | P2 | `2D assets/Shooting Gallery` | `assets/selected/kenney/modes/shooter/Shooting Gallery/` | Targets / harmless target icons | Optional if needing non-violent target visuals. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
-- `SPR_SHOOTER_PLAYER`
+- `SPR_SHOOTER_PLAYER_SHIP`
 - `SPR_SHOOTER_BULLET`
 - `SPR_SHOOTER_ENEMY_01..03`
 - `SPR_SHOOTER_CORE`
-- `SPR_FX_SHOOTER_HIT`
+- `SPR_FX_HIT_SPARK`
+- `T_SHOOTER_ARENA_FLOOR` / `BORDER`
 - `TM_D02_STAGE_00..03`
 
 ---
@@ -192,22 +195,22 @@ Target folder: `assets/selected/kenney/modes/asteroids/`
 
 | Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
 |---|---|---|---|---|
-| P0 | `2D assets/Space Shooter Redux` | `assets/selected/kenney/modes/asteroids/Space Shooter Redux/` | Ship, asteroids/debris, bullets | Primary asteroids source. |
-| P1 | `2D assets/Space Shooter Extension` | `assets/selected/kenney/modes/asteroids/Space Shooter Extension/` | Extra ship/debris/projectile variants | Use only if Redux lacks needed shapes. |
+| P0 | `2D assets/Space Shooter Redux` | `assets/selected/kenney/modes/asteroids/Space Shooter Redux/` | Ship, asteroids/rocks, bullets | Primary asteroids source. |
+| P1 | `2D assets/Space Shooter Extension` | `assets/selected/kenney/modes/asteroids/Space Shooter Extension/` | Extra ship/rock/projectile variants | Use only if Redux lacks needed shapes. |
 | P1 | `2D assets/Simple Space` | `assets/selected/kenney/modes/asteroids/Simple Space/` | Simple ships/rocks/background objects | Good MakeCode-friendly fallback. |
 | P1 | `2D assets/Pixel Shmup` | `assets/selected/kenney/modes/asteroids/Pixel Shmup/` | Pixel bullets/FX | Optional shared shooter source. |
 | P2 | `2D assets/Planets` | `assets/selected/kenney/modes/asteroids/Planets/` | Background-only planets | Optional; do not overfill memory. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
-- `SPR_AST_SHIP`
+- `SPR_AST_PLAYER_SHIP`
 - `ANIM_AST_THRUST`
 - `SPR_AST_BULLET`
-- `SPR_AST_DEBRIS_L`
-- `SPR_AST_DEBRIS_M`
-- `SPR_AST_DEBRIS_S`
-- `SPR_AST_THRUST_FX`
-- `SPR_BG_STARFIELD_TILE` (optional)
+- `SPR_AST_ROCK_L`
+- `SPR_AST_ROCK_M`
+- `SPR_AST_ROCK_S`
+- `SPR_FX_POOF`
+- `SPR_BG_STARFIELD_TILE`
 
 ---
 
@@ -220,30 +223,35 @@ Target folder: `assets/selected/kenney/modes/puzzle/`
 | P0 | `2D assets/Puzzle Assets` | `assets/selected/kenney/modes/puzzle/Puzzle Assets/` | Switches, blocks, targets, puzzle icons | Primary puzzle source. |
 | P1 | `2D assets/Puzzle Assets 2` | `assets/selected/kenney/modes/puzzle/Puzzle Assets 2/` | Extra puzzle pieces / targets | Use if needed. |
 | P0 | `2D assets/Sokoban Pack` | `assets/selected/kenney/modes/puzzle/Sokoban Pack/` | Crates, target pads, push-block logic | Primary D03 source. |
-| P1 | `2D assets/Block Pack (Pixel)` | `assets/selected/kenney/modes/puzzle/Block Pack Pixel/` | Grid blocks / simple obstacles | MakeCode-friendly fallback. |
+| P1 | `2D assets/Block Pack (Pixel)` | `assets/selected/kenney/modes/puzzle/Block Pack Pixel/` | Grid blocks / simple obstacles | Normalized repo folder removes parentheses. |
 | P1 | `2D assets/Boardgame Pack` | `assets/selected/kenney/modes/puzzle/Boardgame Pack/` | Tokens, markers, simple symbols | Useful for D01 tokens and D05 targets. |
 | P1 | `2D assets/Physics Assets` | `assets/selected/kenney/modes/puzzle/Physics Assets/` | Balls, paddles, simple physics props | D05 Pong Court candidate. |
 | P1 | `2D assets/Rolling Ball Assets` | `assets/selected/kenney/modes/puzzle/Rolling Ball Assets/` | Ball variants / rolling objects | D05 or marble-like mini-mechanics. |
 | P1 | `2D assets/Generic Items` | `assets/selected/kenney/modes/puzzle/Generic Items/` | Collectibles / keys / tokens | Shared with hub if needed. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
 - `SPR_PLAYER_PUZZLE`
-- `SPR_D01_TOKEN`
-- `SPR_D01_SWITCH`
-- `SPR_D01_GATE_CLOSED`
-- `SPR_D01_GATE_OPEN`
+- `SPR_TOKEN_LAUNDRY`
+- `SPR_SWITCH_01`
+- `SPR_GATE_01`
+- `SPR_PROP_WASHER` / `DRYER`
+- `SPR_PLAYER_BLOCK`
 - `SPR_BLOCK_CRATE`
-- `SPR_BLOCK_TARGET_PAD`
-- `SPR_PONG_PADDLE`
+- `SPR_TARGET_PAD`
+- `SPR_SWITCH_02`
+- `SPR_PONG_PADDLE_PLAYER`
+- `SPR_PONG_PADDLE_AI`
 - `SPR_PONG_BALL`
-- `SPR_PONG_TARGET_01..03`
-- `T_PUZ_FLOOR_*`
-- `T_PUZ_WALL_*`
-- `T_WAREHOUSE_FLOOR_*`
-- `T_WAREHOUSE_WALL_*`
-- `T_COURT_FLOOR`
-- `T_COURT_LINE`
+- `SPR_PONG_TARGETS_01..03`
+- `T_PUZ_FLOOR_01..02`
+- `T_PUZ_WALL_01..02`
+- `T_PUZ_SWITCH_TILE`
+- `T_PUZ_GATE_TILE`
+- `T_WAREHOUSE_FLOOR_01..02`
+- `T_WAREHOUSE_WALL_01..02`
+- `T_WAREHOUSE_CONVEYOR`
+- `T_COURT_FLOOR` / `LINES`
 - `TM_D01_STAGE_00..03`
 - `TM_D03_STAGE_00..03`
 - `TM_D05_STAGE_00..03`
@@ -256,27 +264,23 @@ Target folder: `assets/selected/kenney/modes/rhythm/`
 
 | Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
 |---|---|---|---|---|
-| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/modes/rhythm/Input Prompts Pixel 16x/` | Tap prompts / timing input hints | Same source as UI, copied here only if mode-local subset is desired. |
+| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/modes/rhythm/Input Prompts Pixel 16x/` | Tap prompts / timing input hints | Normalized repo folder replaces `×` with `x`. |
 | P0 | `UI assets/UI Pixel Pack` | `assets/selected/kenney/modes/rhythm/UI Pixel Pack/` | Timing window, beat ring UI | Primary rhythm UI source. |
 | P1 | `Icons/Game Icons` | `assets/selected/kenney/modes/rhythm/Game Icons/` | Good/Miss icons, door indicators | Shared with global UI. |
 | P1 | `2D assets/RPG Urban Pack` | `assets/selected/kenney/modes/rhythm/RPG Urban Pack/` | Subway-ish walls/floors if suitable | Use only selected urban/interior pieces. |
 | P1 | `2D assets/Roguelike Interior Pack` | `assets/selected/kenney/modes/rhythm/Roguelike Interior Pack/` | Interior corridors / doors | Candidate for D04 staging. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
-- `SPR_RHYTHM_BEAT_RING`
-- `SPR_RHYTHM_GOOD`
-- `SPR_RHYTHM_MISS`
-- `SPR_RHYTHM_DOOR`
-- `T_SUBWAY_FLOOR`
-- `T_SUBWAY_WALL`
+- `SPR_RHYTHM_BEAT_INDICATOR`
+- `SPR_RHYTHM_WINDOW_GOOD` / `OK` / `MISS`
+- `SPR_RHYTHM_TRACK_MARKERS`
+- `SPR_RHYTHM_TRAIN_DOOR`
 - `TM_D04_STAGE_00..03`
 
 ---
 
 ## Shared FX / particles
-
-Use these only as small curated subsets. Do not import full animation libraries.
 
 Target folder: `assets/selected/kenney/ui/`
 
@@ -287,12 +291,13 @@ Target folder: `assets/selected/kenney/ui/`
 | P1 | `2D assets/Smoke Particles` | `assets/selected/kenney/ui/Smoke Particles/` | Respawn/poof FX | Keep frame count low. |
 | P2 | `2D assets/Splat Pack` | `assets/selected/kenney/ui/Splat Pack/` | Avoid unless non-gory and clearly comic | Do not use blood-like splats. |
 
-Expected MakeCode asset IDs:
+Canonical asset IDs:
 
 - `SPR_FX_SPARK_01..02`
 - `SPR_FX_POOF_01..02`
 - `SPR_FX_CONFETTI_01..02`
 - `SPR_FX_GLOW_01..02`
+- `SPR_FX_HIT_SPARK`
 
 ---
 
@@ -315,7 +320,7 @@ Audio files from Kenney can be used as references or, where technically supporte
 | P2 | `Audio/Music Jingles` | `assets/selected/kenney/audio/Music Jingles/` | Stage clear / dungeon clear | Optional. |
 | P2 | `Audio/Music Loops` | `assets/selected/kenney/audio/Music Loops/` | Hub/dungeon loops | Optional; verify MakeCode strategy. |
 
-Expected MakeCode sound IDs:
+Canonical sound IDs:
 
 - `SFX_UI_MOVE`
 - `SFX_UI_CONFIRM`
@@ -324,22 +329,33 @@ Expected MakeCode sound IDs:
 - `SFX_DOOR_LOCKED`
 - `SFX_SAVE`
 - `SFX_COLLECT`
-- `SFX_HIT_COMIC`
-- `SFX_HURT_SOFT`
+- `SFX_HIT`
+- `SFX_HURT`
 - `SFX_WIN_STAGE`
 - `SFX_WIN_DUNGEON`
-- `SFX_RESPAWN`
+- `SFX_LOSE` / `SFX_RESPAWN`
 - `SFX_TRANSITION`
+- `SFX_PUZ_SWITCH`
+- `SFX_PUZ_GATE`
 - `SFX_SHOOTER_SHOT`
 - `SFX_SHOOTER_HIT`
+- `SFX_SHOOTER_CORE_DOWN`
+- `SFX_BLOCK_PUSH`
+- `SFX_BLOCK_PLACE`
+- `SFX_RHYTHM_TICK`
+- `SFX_RHYTHM_HIT_GOOD` / `MISS`
+- `SFX_PONG_BOUNCE`
+- `SFX_PONG_SCORE` / `TARGET_BREAK`
 - `SFX_AST_THRUST`
 - `SFX_AST_SHOT`
 - `SFX_AST_BREAK`
 - `SFX_PLAT_JUMP`
 - `SFX_PLAT_LAND`
-- `SFX_RHYTHM_TICK`
-- `SFX_RHYTHM_GOOD`
-- `SFX_RHYTHM_MISS`
+- `SFX_PLAT_HURT`
+- `SFX_BARREL_ROLL`
+- `SFX_CLIMB`
+- `SFX_META_WARP`
+- `SFX_META_PHASE_CLEAR`
 
 ---
 
@@ -375,8 +391,8 @@ Goal:
 - `SPR_PLAYER_TOPDOWN`
 - `SPR_DOOR_DUNGEON`
 - `SPR_NPC_SAVEHOUSE`
+- `SPR_INTERACT_PROMPT`
 - `TM_HUB_11`
-- one visible A-button prompt
 
 ### Batch 2: Full hub grid
 
@@ -403,9 +419,7 @@ Copy curated files from:
 - `2D assets/Pixel Platformer Industrial Expansion`
 - `2D assets/Platformer Pack Industrial`
 
-Goal:
-
-- D07 and D08 visible and playable.
+Goal: D07 and D08 visible and playable.
 
 ### Batch 4: Shooter and Asteroids dungeons
 
@@ -416,9 +430,7 @@ Copy curated files from:
 - `2D assets/Space Shooter Redux`
 - `2D assets/Simple Space`
 
-Goal:
-
-- D02 and D06 visible and playable.
+Goal: D02 and D06 visible and playable.
 
 ### Batch 5: Puzzle and Rhythm dungeons
 
@@ -431,9 +443,7 @@ Copy curated files from:
 - `UI assets/UI Pixel Pack`
 - `Icons/Game Icons`
 
-Goal:
-
-- D01, D03, D04, D05 readable and playable.
+Goal: D01, D03, D04, D05 readable and playable.
 
 ### Batch 6: Audio pass 1
 
@@ -445,6 +455,4 @@ Copy curated files from:
 - `Audio/Retro Sounds 1`
 - `Audio/Sci-Fi Sounds`
 
-Goal:
-
-- Basic interaction, collect, win, shooter, asteroids, platform and rhythm cues.
+Goal: Basic interaction, collect, win, shooter, asteroids, platform and rhythm cues.

--- a/docs/KENNEY_ASSET_MAP.md
+++ b/docs/KENNEY_ASSET_MAP.md
@@ -1,0 +1,450 @@
+# KENNEY_ASSET_MAP.md
+
+Mapping from the purchased Kenney All-in-1 package overview to NeonKiez repo folders.
+
+Source overview: `ce7c6a16-4e5d-456b-a986-4e1cfbabeafd.html` (Kenney Game Assets All-in-1 package index). The overview lists 239 packages across 2D, 3D, Audio, Icons, UI, and Other categories. It provides package folder paths, not individual PNG/WAV filenames. Therefore this document maps **Kenney package folders** to repo folders and expected MakeCode asset IDs. Exact file-level selection happens after the bundle is unpacked locally.
+
+## Important rules
+
+- Use only Kenney All-in-1 assets unless the project owner explicitly approves another source.
+- Do not commit the full purchased archive.
+- Copy only curated subsets into `assets/selected/kenney/`.
+- Keep original package names in subfolders when copying files, so provenance stays obvious.
+- Prefer 2D, pixel, UI, icon, and audio packs. Avoid 3D packs for v1.0.
+- MakeCode Arcade target: 16x16 tiles where possible, small sprite sets, limited palette, no giant sheets.
+
+## Recommended subfolder pattern
+
+When copying a curated subset, preserve the package name below the target area:
+
+```text
+assets/selected/kenney/<area>/<Kenney Package Name>/...
+```
+
+Example:
+
+```text
+assets/selected/kenney/hub/RPG Urban Pack/...
+assets/selected/kenney/modes/asteroids/Space Shooter Redux/...
+```
+
+## Priority legend
+
+- P0: needed first for visibility / MVP functionality.
+- P1: needed for playable v1.0 content.
+- P2: polish / optional for v1.0.
+- Avoid: do not use for v1.0 unless explicitly approved.
+
+---
+
+## Hub / Neon City
+
+Target folder: `assets/selected/kenney/hub/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `2D assets/RPG Urban Pack` | `assets/selected/kenney/hub/RPG Urban Pack/` | Hub streets, sidewalks, buildings, doors, city props | Primary hub pack. Use as first source for `TM_HUB_00..22`. |
+| P0 | `2D assets/Roguelike City Pack` | `assets/selected/kenney/hub/Roguelike City Pack/` | Compact city tiles, urban props | Good fallback for MakeCode-friendly small tiles. |
+| P1 | `2D assets/Tiny Town` | `assets/selected/kenney/hub/Tiny Town/` | Simplified city props / readable fallback tiles | Use only if style fits after palette test. |
+| P1 | `2D assets/Pico-8 City` | `assets/selected/kenney/hub/Pico-8 City/` | Low-color city look, palette-friendly props | Candidate for MakeCode palette compatibility. |
+| P1 | `2D assets/Character Pack` | `assets/selected/kenney/hub/Character Pack/` | Hub NPCs / civilian silhouettes | Select only small readable characters. |
+| P1 | `2D assets/Character Pack Redux` | `assets/selected/kenney/hub/Character Pack Redux/` | Hub NPC variants | Alternative to Character Pack. |
+| P1 | `2D assets/Roguelike Characters Pack` | `assets/selected/kenney/hub/Roguelike Characters Pack/` | Top-down NPCs / player placeholder | Prefer if sprites are small and readable. |
+| P1 | `2D assets/Robot Pack` | `assets/selected/kenney/hub/Robot Pack/` | Friendly bots, comic blockers, dungeon bots | Good for child-friendly non-human enemies. |
+| P1 | `2D assets/Generic Items` | `assets/selected/kenney/hub/Generic Items/` | Collectibles, savehouse props, inventory objects | Use for small props/items. |
+| P2 | `2D assets/Emote Pack` | `assets/selected/kenney/hub/Emote Pack/` | NPC feedback bubbles | Optional UX polish. |
+| P2 | `2D assets/Googly Eyes` | `assets/selected/kenney/hub/Googly Eyes/` | Comic prop accents | Optional, use sparingly. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_PLAYER_TOPDOWN`
+- `SPR_NPC_GENERIC_01..03`
+- `SPR_NPC_SAVEHOUSE`
+- `SPR_DOOR_DUNGEON`
+- `SPR_DOOR_FINAL`
+- `T_HUB_FLOOR_*`
+- `T_HUB_WALL_*`
+- `T_HUB_ROAD_*`
+- `T_HUB_PROP_*`
+- `TM_HUB_00..22`
+
+---
+
+## Overworld / Outskirts
+
+Target folder: `assets/selected/kenney/overworld/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P1 | `2D assets/Tiny Town` | `assets/selected/kenney/overworld/Tiny Town/` | Simple overworld/outskirts tiles | Use if hub needs edge/outskirts rooms. |
+| P1 | `2D assets/Foliage Pack` | `assets/selected/kenney/overworld/Foliage Pack/` | Trees, bushes, outdoor props | Select small readable objects only. |
+| P1 | `2D assets/Foliage Sprites` | `assets/selected/kenney/overworld/Foliage Sprites/` | Outdoor sprite props | Alternative/extension to Foliage Pack. |
+| P1 | `2D assets/Road Textures` | `assets/selected/kenney/overworld/Road Textures/` | Roads / asphalt / pavement | Check tile size and palette first. |
+| P1 | `2D assets/Road Textures (Classic)` | `assets/selected/kenney/overworld/Road Textures Classic/` | Classic road texture fallback | Use if more retro-readable. |
+| P2 | `2D assets/Cartography Pack` | `assets/selected/kenney/overworld/Cartography Pack/` | Map/minimap style graphics | Optional; not core gameplay. |
+
+Expected MakeCode asset IDs:
+
+- `T_OVERWORLD_GRASS_*`
+- `T_OVERWORLD_PATH_*`
+- `T_OVERWORLD_ROAD_*`
+- `T_OVERWORLD_TREE_*`
+- `TM_OVERWORLD_01..02` (only if used)
+
+---
+
+## UI / HUD / Input prompts
+
+Target folder: `assets/selected/kenney/ui/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/ui/Input Prompts Pixel 16x/` | A/B/Menu prompts, tutorial hints | Primary input prompt source. Rename `×` to `x` in repo path for filesystem simplicity. |
+| P0 | `UI assets/UI Pixel Pack` | `assets/selected/kenney/ui/UI Pixel Pack/` | HUD frames, small UI panels, buttons | Primary pixel UI pack. |
+| P0 | `Icons/Game Icons` | `assets/selected/kenney/ui/Game Icons/` | Tool icons, inventory icons, reward icons | Primary icon source. |
+| P1 | `Icons/Game Icons Expansion` | `assets/selected/kenney/ui/Game Icons Expansion/` | Additional icons | Use only if base Game Icons is insufficient. |
+| P1 | `UI assets/Cursor Pixel Pack` | `assets/selected/kenney/ui/Cursor Pixel Pack/` | Menu cursor / selector | Pixel-friendly. |
+| P1 | `2D assets/Development Essentials` | `assets/selected/kenney/ui/Development Essentials/` | Debug markers, simple placeholders | Good for development-only visuals. |
+| P1 | `Icons/1-Bit Input Prompts Pixel 16×` | `assets/selected/kenney/ui/1-Bit Input Prompts Pixel 16x/` | Minimal input prompts fallback | Use if low-color UI is desired. |
+| P2 | `UI assets/UI Pack - Sci-fi` | `assets/selected/kenney/ui/UI Pack - Sci-fi/` | Neon/glitch menu accents | Optional polish; verify style/palette. |
+| P2 | `UI assets/UI Pack` | `assets/selected/kenney/ui/UI Pack/` | Generic UI fallback | Use sparingly. |
+| P2 | `UI assets/UI Pack - Pixel Adventure` | `assets/selected/kenney/ui/UI Pack - Pixel Adventure/` | Pixel menu fallback | Optional. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_UI_HEART_FULL`
+- `SPR_UI_HEART_EMPTY`
+- `SPR_UI_TOOL_FREEZECAM`
+- `SPR_UI_TOOL_CONFETTI`
+- `SPR_UI_TOOL_SOAP`
+- `SPR_UI_TOOL_DECOY`
+- `SPR_UI_TOOL_TAGGER`
+- `SPR_UI_CURSOR`
+- `SPR_INPUT_A`
+- `SPR_INPUT_B`
+- `SPR_INPUT_MENU`
+- `SPR_RHYTHM_BEAT_INDICATOR`
+- `SPR_RHYTHM_GOOD`
+- `SPR_RHYTHM_MISS`
+
+---
+
+## Platform modes: D07 Video Store Platform Trial, D08 Construction Donkey Tower
+
+Target folder: `assets/selected/kenney/modes/platform/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `2D assets/Pixel Platformer` | `assets/selected/kenney/modes/platform/Pixel Platformer/` | Platform player, ground, hazards, collectibles | Primary platform source. |
+| P0 | `2D assets/Platformer Characters 1` | `assets/selected/kenney/modes/platform/Platformer Characters 1/` | Platform characters / enemies | Use for D07/D08 characters if style fits. |
+| P0 | `2D assets/Pixel Platformer Industrial Expansion` | `assets/selected/kenney/modes/platform/Pixel Platformer Industrial Expansion/` | Construction / warehouse / industrial tiles | Primary D08 construction source. |
+| P1 | `2D assets/Platformer Pack Industrial` | `assets/selected/kenney/modes/platform/Platformer Pack Industrial/` | Girders, ladders, industrial props | D08 Donkey Tower candidate. |
+| P1 | `2D assets/Platformer Assets Pixel` | `assets/selected/kenney/modes/platform/Platformer Assets Pixel/` | Pixel platform tiles | Alternative to Pixel Platformer. |
+| P1 | `2D assets/Platformer Assets Extra Animations & Enemies` | `assets/selected/kenney/modes/platform/Platformer Assets Extra Animations and Enemies/` | Extra enemy animations | Use sparingly; avoid animation bloat. |
+| P1 | `2D assets/Pixel Platformer Blocks` | `assets/selected/kenney/modes/platform/Pixel Platformer Blocks/` | Platforms / blocks / stage geometry | Good for simple geometry. |
+| P2 | `2D assets/1-Bit Platformer Pack` | `assets/selected/kenney/modes/platform/1-Bit Platformer Pack/` | Low-color fallback | Only if style direction changes. |
+| P2 | `2D assets/Pico-8 Platformer` | `assets/selected/kenney/modes/platform/Pico-8 Platformer/` | Palette-friendly fallback | Optional. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_PLAT_PLAYER`
+- `ANIM_PLAT_PLAYER_WALK`
+- `SPR_PLAT_ENEMY_01..02`
+- `SPR_PLAT_COLLECTIBLE`
+- `SPR_DONKEY_BARREL`
+- `SPR_DONKEY_FOREMAN_BOT`
+- `T_PLAT_GROUND_*`
+- `T_PLAT_PLATFORM_*`
+- `T_PLAT_HAZARD_*`
+- `T_DONKEY_GIRDER_*`
+- `T_DONKEY_LADDER`
+- `TM_D07_STAGE_00..03`
+- `TM_D08_STAGE_00..03`
+
+---
+
+## Shooter mode: D02 Rooftop Invaders
+
+Target folder: `assets/selected/kenney/modes/shooter/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `2D assets/Topdown Shooter (Pixel)` | `assets/selected/kenney/modes/shooter/Topdown Shooter Pixel/` | Player ship, enemies, bullets | Primary shooter source for MakeCode-friendly pixel style. |
+| P1 | `2D assets/Topdown Shooter` | `assets/selected/kenney/modes/shooter/Topdown Shooter/` | Higher-res source/fallback | Use only selected small sprites if palette/size works. |
+| P1 | `2D assets/Pixel Shmup` | `assets/selected/kenney/modes/shooter/Pixel Shmup/` | Invader-like enemies, bullets, powerups | Good for classic arcade feel. |
+| P1 | `2D assets/Space Shooter Redux` | `assets/selected/kenney/modes/shooter/Space Shooter Redux/` | Enemy formations / projectiles / core | Can be shared with asteroids. |
+| P2 | `2D assets/Shooting Gallery` | `assets/selected/kenney/modes/shooter/Shooting Gallery/` | Targets / harmless target icons | Optional if needing non-violent target visuals. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_SHOOTER_PLAYER`
+- `SPR_SHOOTER_BULLET`
+- `SPR_SHOOTER_ENEMY_01..03`
+- `SPR_SHOOTER_CORE`
+- `SPR_FX_SHOOTER_HIT`
+- `TM_D02_STAGE_00..03`
+
+---
+
+## Asteroids mode: D06 Arcade Museum Asteroids
+
+Target folder: `assets/selected/kenney/modes/asteroids/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `2D assets/Space Shooter Redux` | `assets/selected/kenney/modes/asteroids/Space Shooter Redux/` | Ship, asteroids/debris, bullets | Primary asteroids source. |
+| P1 | `2D assets/Space Shooter Extension` | `assets/selected/kenney/modes/asteroids/Space Shooter Extension/` | Extra ship/debris/projectile variants | Use only if Redux lacks needed shapes. |
+| P1 | `2D assets/Simple Space` | `assets/selected/kenney/modes/asteroids/Simple Space/` | Simple ships/rocks/background objects | Good MakeCode-friendly fallback. |
+| P1 | `2D assets/Pixel Shmup` | `assets/selected/kenney/modes/asteroids/Pixel Shmup/` | Pixel bullets/FX | Optional shared shooter source. |
+| P2 | `2D assets/Planets` | `assets/selected/kenney/modes/asteroids/Planets/` | Background-only planets | Optional; do not overfill memory. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_AST_SHIP`
+- `ANIM_AST_THRUST`
+- `SPR_AST_BULLET`
+- `SPR_AST_DEBRIS_L`
+- `SPR_AST_DEBRIS_M`
+- `SPR_AST_DEBRIS_S`
+- `SPR_AST_THRUST_FX`
+- `SPR_BG_STARFIELD_TILE` (optional)
+
+---
+
+## Puzzle modes: D01 Laundromat Labyrinth, D03 Warehouse Blockworks, D05 School Pong Court
+
+Target folder: `assets/selected/kenney/modes/puzzle/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `2D assets/Puzzle Assets` | `assets/selected/kenney/modes/puzzle/Puzzle Assets/` | Switches, blocks, targets, puzzle icons | Primary puzzle source. |
+| P1 | `2D assets/Puzzle Assets 2` | `assets/selected/kenney/modes/puzzle/Puzzle Assets 2/` | Extra puzzle pieces / targets | Use if needed. |
+| P0 | `2D assets/Sokoban Pack` | `assets/selected/kenney/modes/puzzle/Sokoban Pack/` | Crates, target pads, push-block logic | Primary D03 source. |
+| P1 | `2D assets/Block Pack (Pixel)` | `assets/selected/kenney/modes/puzzle/Block Pack Pixel/` | Grid blocks / simple obstacles | MakeCode-friendly fallback. |
+| P1 | `2D assets/Boardgame Pack` | `assets/selected/kenney/modes/puzzle/Boardgame Pack/` | Tokens, markers, simple symbols | Useful for D01 tokens and D05 targets. |
+| P1 | `2D assets/Physics Assets` | `assets/selected/kenney/modes/puzzle/Physics Assets/` | Balls, paddles, simple physics props | D05 Pong Court candidate. |
+| P1 | `2D assets/Rolling Ball Assets` | `assets/selected/kenney/modes/puzzle/Rolling Ball Assets/` | Ball variants / rolling objects | D05 or marble-like mini-mechanics. |
+| P1 | `2D assets/Generic Items` | `assets/selected/kenney/modes/puzzle/Generic Items/` | Collectibles / keys / tokens | Shared with hub if needed. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_PLAYER_PUZZLE`
+- `SPR_D01_TOKEN`
+- `SPR_D01_SWITCH`
+- `SPR_D01_GATE_CLOSED`
+- `SPR_D01_GATE_OPEN`
+- `SPR_BLOCK_CRATE`
+- `SPR_BLOCK_TARGET_PAD`
+- `SPR_PONG_PADDLE`
+- `SPR_PONG_BALL`
+- `SPR_PONG_TARGET_01..03`
+- `T_PUZ_FLOOR_*`
+- `T_PUZ_WALL_*`
+- `T_WAREHOUSE_FLOOR_*`
+- `T_WAREHOUSE_WALL_*`
+- `T_COURT_FLOOR`
+- `T_COURT_LINE`
+- `TM_D01_STAGE_00..03`
+- `TM_D03_STAGE_00..03`
+- `TM_D05_STAGE_00..03`
+
+---
+
+## Rhythm mode: D04 Subway Timing
+
+Target folder: `assets/selected/kenney/modes/rhythm/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `Icons/Input Prompts Pixel 16×` | `assets/selected/kenney/modes/rhythm/Input Prompts Pixel 16x/` | Tap prompts / timing input hints | Same source as UI, copied here only if mode-local subset is desired. |
+| P0 | `UI assets/UI Pixel Pack` | `assets/selected/kenney/modes/rhythm/UI Pixel Pack/` | Timing window, beat ring UI | Primary rhythm UI source. |
+| P1 | `Icons/Game Icons` | `assets/selected/kenney/modes/rhythm/Game Icons/` | Good/Miss icons, door indicators | Shared with global UI. |
+| P1 | `2D assets/RPG Urban Pack` | `assets/selected/kenney/modes/rhythm/RPG Urban Pack/` | Subway-ish walls/floors if suitable | Use only selected urban/interior pieces. |
+| P1 | `2D assets/Roguelike Interior Pack` | `assets/selected/kenney/modes/rhythm/Roguelike Interior Pack/` | Interior corridors / doors | Candidate for D04 staging. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_RHYTHM_BEAT_RING`
+- `SPR_RHYTHM_GOOD`
+- `SPR_RHYTHM_MISS`
+- `SPR_RHYTHM_DOOR`
+- `T_SUBWAY_FLOOR`
+- `T_SUBWAY_WALL`
+- `TM_D04_STAGE_00..03`
+
+---
+
+## Shared FX / particles
+
+Use these only as small curated subsets. Do not import full animation libraries.
+
+Target folder: `assets/selected/kenney/ui/`
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P1 | `2D assets/Explosion Pack` | `assets/selected/kenney/ui/Explosion Pack/` | Comic hit/spark frames | Use non-violent sparks/poofs only; no destruction language. |
+| P1 | `2D assets/Particle Pack` | `assets/selected/kenney/ui/Particle Pack/` | Collect/win FX | Small subset only. |
+| P1 | `2D assets/Smoke Particles` | `assets/selected/kenney/ui/Smoke Particles/` | Respawn/poof FX | Keep frame count low. |
+| P2 | `2D assets/Splat Pack` | `assets/selected/kenney/ui/Splat Pack/` | Avoid unless non-gory and clearly comic | Do not use blood-like splats. |
+
+Expected MakeCode asset IDs:
+
+- `SPR_FX_SPARK_01..02`
+- `SPR_FX_POOF_01..02`
+- `SPR_FX_CONFETTI_01..02`
+- `SPR_FX_GLOW_01..02`
+
+---
+
+## Audio
+
+Target folder: `assets/selected/kenney/audio/`
+
+Audio files from Kenney can be used as references or, where technically supported, converted/rebuilt into MakeCode-compatible sound/music expressions. Avoid large audio imports in v1.0.
+
+| Priority | Source package path in Kenney bundle | Copy to repo folder | Use for | Notes |
+|---|---|---|---|---|
+| P0 | `Audio/Interface Sounds` | `assets/selected/kenney/audio/Interface Sounds/` | Menu navigation, confirm/back | First audio batch. |
+| P0 | `Audio/UI Audio` | `assets/selected/kenney/audio/UI Audio/` | UI feedback, prompts | Use with Interface Sounds. |
+| P1 | `Audio/Digital Audio` | `assets/selected/kenney/audio/Digital Audio/` | Save, collect, mode transition | Good retro digital cues. |
+| P1 | `Audio/Retro Sounds 1` | `assets/selected/kenney/audio/Retro Sounds 1/` | Arcade SFX | Use small subset. |
+| P1 | `Audio/Retro Sounds 2` | `assets/selected/kenney/audio/Retro Sounds 2/` | Arcade SFX variants | Use only if needed. |
+| P1 | `Audio/Sci-Fi Sounds` | `assets/selected/kenney/audio/Sci-Fi Sounds/` | Shooter/Asteroids SFX | D02/D06. |
+| P1 | `Audio/RPG Audio` | `assets/selected/kenney/audio/RPG Audio/` | Collect/save/interact alternatives | Hub/Dungeons. |
+| P1 | `Audio/Impact Sounds` | `assets/selected/kenney/audio/Impact Sounds/` | Soft hit/impact feedback | Use non-violent, gentle impacts. |
+| P2 | `Audio/Music Jingles` | `assets/selected/kenney/audio/Music Jingles/` | Stage clear / dungeon clear | Optional. |
+| P2 | `Audio/Music Loops` | `assets/selected/kenney/audio/Music Loops/` | Hub/dungeon loops | Optional; verify MakeCode strategy. |
+
+Expected MakeCode sound IDs:
+
+- `SFX_UI_MOVE`
+- `SFX_UI_CONFIRM`
+- `SFX_UI_BACK`
+- `SFX_DOOR_ENTER`
+- `SFX_DOOR_LOCKED`
+- `SFX_SAVE`
+- `SFX_COLLECT`
+- `SFX_HIT_COMIC`
+- `SFX_HURT_SOFT`
+- `SFX_WIN_STAGE`
+- `SFX_WIN_DUNGEON`
+- `SFX_RESPAWN`
+- `SFX_TRANSITION`
+- `SFX_SHOOTER_SHOT`
+- `SFX_SHOOTER_HIT`
+- `SFX_AST_THRUST`
+- `SFX_AST_SHOT`
+- `SFX_AST_BREAK`
+- `SFX_PLAT_JUMP`
+- `SFX_PLAT_LAND`
+- `SFX_RHYTHM_TICK`
+- `SFX_RHYTHM_GOOD`
+- `SFX_RHYTHM_MISS`
+
+---
+
+## Avoid for v1.0
+
+Do not copy these unless explicitly approved:
+
+| Source package category/path | Reason |
+|---|---|
+| `3D assets/*` | MakeCode Arcade target is 2D; 3D models are out of scope for v1.0. |
+| `2D assets/Isometric *` | Current requirement is top-down/orthogonal hub; isometric may cause perspective mismatch. |
+| `2D assets/Axonometric Blocks` | Perspective mismatch unless a later 2.5D decision is made. |
+| `2D assets/Monochrome Pirates`, `Pirate Pack`, `RTS Medieval`, `Fantasy UI Borders` | Theme mismatch for NeonKiez v1.0. |
+| Full audio/music libraries | Too much repo weight; select only needed cues. |
+| Full spritesheets without curation | Memory/readability risk in MakeCode Arcade. |
+
+---
+
+## First asset batches
+
+### Batch 1: Hub visibility and start room
+
+Copy curated files from:
+
+- `2D assets/RPG Urban Pack` -> `assets/selected/kenney/hub/RPG Urban Pack/`
+- `2D assets/Roguelike City Pack` -> `assets/selected/kenney/hub/Roguelike City Pack/`
+- `2D assets/Roguelike Characters Pack` -> `assets/selected/kenney/hub/Roguelike Characters Pack/`
+- `Icons/Input Prompts Pixel 16×` -> `assets/selected/kenney/ui/Input Prompts Pixel 16x/`
+- `UI assets/UI Pixel Pack` -> `assets/selected/kenney/ui/UI Pixel Pack/`
+
+Goal:
+
+- `SPR_PLAYER_TOPDOWN`
+- `SPR_DOOR_DUNGEON`
+- `SPR_NPC_SAVEHOUSE`
+- `TM_HUB_11`
+- one visible A-button prompt
+
+### Batch 2: Full hub grid
+
+Copy curated files from:
+
+- `2D assets/RPG Urban Pack`
+- `2D assets/Roguelike City Pack`
+- `2D assets/Generic Items`
+- `2D assets/Robot Pack`
+
+Goal:
+
+- `TM_HUB_00..22`
+- all dungeon doors visible
+- savehouse visible
+- hub props added without clutter
+
+### Batch 3: Platform dungeons
+
+Copy curated files from:
+
+- `2D assets/Pixel Platformer`
+- `2D assets/Platformer Characters 1`
+- `2D assets/Pixel Platformer Industrial Expansion`
+- `2D assets/Platformer Pack Industrial`
+
+Goal:
+
+- D07 and D08 visible and playable.
+
+### Batch 4: Shooter and Asteroids dungeons
+
+Copy curated files from:
+
+- `2D assets/Topdown Shooter (Pixel)`
+- `2D assets/Pixel Shmup`
+- `2D assets/Space Shooter Redux`
+- `2D assets/Simple Space`
+
+Goal:
+
+- D02 and D06 visible and playable.
+
+### Batch 5: Puzzle and Rhythm dungeons
+
+Copy curated files from:
+
+- `2D assets/Puzzle Assets`
+- `2D assets/Sokoban Pack`
+- `2D assets/Boardgame Pack`
+- `2D assets/Physics Assets`
+- `UI assets/UI Pixel Pack`
+- `Icons/Game Icons`
+
+Goal:
+
+- D01, D03, D04, D05 readable and playable.
+
+### Batch 6: Audio pass 1
+
+Copy curated files from:
+
+- `Audio/Interface Sounds`
+- `Audio/UI Audio`
+- `Audio/Digital Audio`
+- `Audio/Retro Sounds 1`
+- `Audio/Sci-Fi Sounds`
+
+Goal:
+
+- Basic interaction, collect, win, shooter, asteroids, platform and rhythm cues.

--- a/docs/KENNEY_BATCH_01_FILE_SELECTION.md
+++ b/docs/KENNEY_BATCH_01_FILE_SELECTION.md
@@ -1,0 +1,252 @@
+# KENNEY_BATCH_01_FILE_SELECTION.md
+
+Exact file/folder mapping for **Batch 1: Hub visibility and start room**.
+
+Source basis: uploaded `kenney_filelist.txt` generated from the local Kenney All-in-1 3.4.0 installation. The list contains 101,614 files. Many relevant Kenney packs use numbered files such as `tile_0000.png`; without visual image inspection those numbers cannot be honestly mapped to semantic labels like "road" or "door". Therefore this batch uses a two-step workflow:
+
+1. Copy exact candidate pools from the Kenney bundle into `assets/working/palette-tests/kenney-batch1/`.
+2. The asset agent visually inspects those candidate pools, chooses the final small subset, and copies only final selected files into `assets/selected/kenney/...`.
+
+Do **not** import full candidate pools into MakeCode Arcade.
+
+---
+
+## Batch 1 goals
+
+The goal is to make the game visibly playable at boot:
+
+- `SPR_PLAYER_TOPDOWN`
+- `SPR_DOOR_DUNGEON`
+- `SPR_NPC_SAVEHOUSE`
+- `SPR_INPUT_A`
+- `TM_HUB_11`
+- first hub floor/wall/road/prop tiles
+
+---
+
+## Exact staging copy map
+
+### 1) Hub city tiles: RPG Urban Pack
+
+Copy these exact files/folders from local Kenney root:
+
+```text
+2D assets/RPG Urban Pack/License.txt
+2D assets/RPG Urban Pack/Preview.png
+2D assets/RPG Urban Pack/Sample.png
+2D assets/RPG Urban Pack/Tilemap/tilemap.png
+2D assets/RPG Urban Pack/Tilemap/tilemap_packed.png
+2D assets/RPG Urban Pack/Tilemap/tilemap.txt
+2D assets/RPG Urban Pack/Tiles/tile_0000.png .. tile_0485.png
+2D assets/RPG Urban Pack/Bonus/Tilemap/tilemap.png
+2D assets/RPG Urban Pack/Bonus/Tilemap/tilemap_packed.png
+2D assets/RPG Urban Pack/Bonus/Tiles/tile_0000.png .. tile_0089.png
+```
+
+Stage to:
+
+```text
+assets/working/palette-tests/kenney-batch1/hub/RPG Urban Pack/
+```
+
+Final selected files should later be copied to:
+
+```text
+assets/selected/kenney/hub/RPG Urban Pack/
+```
+
+Use for final asset IDs:
+
+```text
+T_HUB_FLOOR_*
+T_HUB_WALL_*
+T_HUB_ROAD_*
+T_HUB_PROP_*
+TM_HUB_11
+```
+
+---
+
+### 2) Hub city fallback tiles: Roguelike City Pack
+
+Copy these exact files/folders from local Kenney root:
+
+```text
+2D assets/Roguelike City Pack/License.txt
+2D assets/Roguelike City Pack/Preview.png
+2D assets/Roguelike City Pack/Sample.png
+2D assets/Roguelike City Pack/Tilesheet.txt
+2D assets/Roguelike City Pack/Tilemap/tilemap.png
+2D assets/Roguelike City Pack/Tilemap/tilemap_packed.png
+2D assets/Roguelike City Pack/Tiles/tile_0000.png .. tile_1035.png
+```
+
+Stage to:
+
+```text
+assets/working/palette-tests/kenney-batch1/hub/Roguelike City Pack/
+```
+
+Final selected files should later be copied to:
+
+```text
+assets/selected/kenney/hub/Roguelike City Pack/
+```
+
+Use for final asset IDs:
+
+```text
+T_HUB_FLOOR_*
+T_HUB_WALL_*
+T_HUB_ROAD_*
+T_HUB_PROP_*
+SPR_DOOR_DUNGEON or T_MARK_DOOR_* if visually suitable
+```
+
+---
+
+### 3) Top-down character sheet: Roguelike Characters Pack
+
+Copy these exact files from local Kenney root:
+
+```text
+2D assets/Roguelike Characters Pack/License.txt
+2D assets/Roguelike Characters Pack/Preview.png
+2D assets/Roguelike Characters Pack/Sample.png
+2D assets/Roguelike Characters Pack/Spritesheet/roguelikeChar_transparent.png
+2D assets/Roguelike Characters Pack/Spritesheet/roguelikeChar_magenta.png
+2D assets/Roguelike Characters Pack/Spritesheet/spritesheetInfo.txt
+```
+
+Stage to:
+
+```text
+assets/working/palette-tests/kenney-batch1/hub/Roguelike Characters Pack/
+```
+
+Final selected/cropped sprites should later be copied to:
+
+```text
+assets/selected/kenney/hub/Roguelike Characters Pack/
+```
+
+Use for final asset IDs:
+
+```text
+SPR_PLAYER_TOPDOWN
+SPR_NPC_SAVEHOUSE
+SPR_NPC_GENERIC_01
+```
+
+Note: This pack is sheet-based, not pre-sliced into named character PNG files. The asset agent must crop final character sprites from the transparent spritesheet.
+
+---
+
+### 4) Input prompt: Input Prompts Pixel 16x
+
+Copy these exact files/folders from local Kenney root:
+
+```text
+Icons/Input Prompts Pixel 16×/License.txt
+Icons/Input Prompts Pixel 16×/Preview.png
+Icons/Input Prompts Pixel 16×/Tilesheet.txt
+Icons/Input Prompts Pixel 16×/Tilemap/tilemap.png
+Icons/Input Prompts Pixel 16×/Tilemap/tilemap_packed.png
+Icons/Input Prompts Pixel 16×/Tiles/tile_0000.png .. tile_0815.png
+```
+
+Stage to:
+
+```text
+assets/working/palette-tests/kenney-batch1/ui/Input Prompts Pixel 16x/
+```
+
+Final selected files should later be copied to:
+
+```text
+assets/selected/kenney/ui/Input Prompts Pixel 16x/
+```
+
+Use for final asset IDs:
+
+```text
+SPR_INPUT_A
+SPR_INPUT_B
+SPR_INPUT_MENU
+```
+
+Note: Source folder uses the Unicode `×`; repo folder uses ASCII `x` for safer paths.
+
+---
+
+### 5) Pixel UI sheet: UI Pixel Pack
+
+Copy these exact files from local Kenney root:
+
+```text
+UI assets/UI Pixel Pack/Instructions.txt
+UI assets/UI Pixel Pack/License.txt
+UI assets/UI Pixel Pack/Preview.png
+UI assets/UI Pixel Pack/Spritesheet/UIpackSheet_transparent.png
+UI assets/UI Pixel Pack/Spritesheet/UIpackSheet_magenta.png
+```
+
+Stage to:
+
+```text
+assets/working/palette-tests/kenney-batch1/ui/UI Pixel Pack/
+```
+
+Final selected/cropped sprites should later be copied to:
+
+```text
+assets/selected/kenney/ui/UI Pixel Pack/
+```
+
+Use for final asset IDs:
+
+```text
+SPR_UI_DIALOG_FRAME
+SPR_UI_CURSOR
+SPR_UI_HEART_FULL
+SPR_UI_HEART_EMPTY
+```
+
+---
+
+## Final selection rules for the asset agent
+
+After staging, the asset agent must inspect images and choose a **small MakeCode-safe subset**:
+
+### Required final subset size target
+
+| Area | Target count |
+|---|---:|
+| Hub ground/road/wall tiles | 12-24 tiles |
+| Hub props/signs/door candidates | 6-12 sprites/tiles |
+| Top-down player/NPC sprites | 3-6 cropped sprites |
+| Input prompts | 1-3 icons |
+| UI elements | 2-6 sprites |
+
+### Hard rules
+
+- Do not import all staged candidate files into MakeCode.
+- Prefer 16x16 or small assets.
+- Prefer transparent PNGs over magenta-background PNGs.
+- Avoid perspective mismatch: no isometric/axonometric in Batch 1.
+- Keep final files in `assets/selected/kenney/...` only after visual approval by the asset agent.
+- Update `docs/ASSET_MANIFEST.md` with final exact filenames.
+
+---
+
+## Automation
+
+Use `tools/select_kenney_batch1.ps1` to stage the exact candidate pools listed above.
+
+Example:
+
+```powershell
+.\tools\select_kenney_batch1.ps1 -KenneyRoot "C:\Path\To\Kenney" -RepoRoot "C:\Path\To\NeonKiez"
+```
+
+`-KenneyRoot` must point to the folder containing `2D assets`, `Icons`, `UI assets`, and `Audio`.

--- a/docs/KENNEY_BATCH_01_FILE_SELECTION.md
+++ b/docs/KENNEY_BATCH_01_FILE_SELECTION.md
@@ -9,6 +9,8 @@ Source basis: uploaded `kenney_filelist.txt` generated from the local Kenney All
 
 Do **not** import full candidate pools into MakeCode Arcade.
 
+Canonical asset IDs come from `.github/ASSET_REQUIREMENTS.md`.
+
 ---
 
 ## Batch 1 goals
@@ -18,7 +20,7 @@ The goal is to make the game visibly playable at boot:
 - `SPR_PLAYER_TOPDOWN`
 - `SPR_DOOR_DUNGEON`
 - `SPR_NPC_SAVEHOUSE`
-- `SPR_INPUT_A`
+- `SPR_INTERACT_PROMPT`
 - `TM_HUB_11`
 - first hub floor/wall/road/prop tiles
 
@@ -58,10 +60,12 @@ assets/selected/kenney/hub/RPG Urban Pack/
 Use for final asset IDs:
 
 ```text
-T_HUB_FLOOR_*
-T_HUB_WALL_*
-T_HUB_ROAD_*
-T_HUB_PROP_*
+T_HUB_FLOOR_01..03
+T_HUB_WALL_01..03
+T_HUB_EDGE / T_HUB_BORDER
+T_HUB_SIGN_01..06
+T_HUB_PROP_01..10
+T_HUB_DECAL_01..06
 TM_HUB_11
 ```
 
@@ -96,11 +100,13 @@ assets/selected/kenney/hub/Roguelike City Pack/
 Use for final asset IDs:
 
 ```text
-T_HUB_FLOOR_*
-T_HUB_WALL_*
-T_HUB_ROAD_*
-T_HUB_PROP_*
-SPR_DOOR_DUNGEON or T_MARK_DOOR_* if visually suitable
+T_HUB_FLOOR_01..03
+T_HUB_WALL_01..03
+T_HUB_EDGE / T_HUB_BORDER
+T_HUB_SIGN_01..06
+T_HUB_PROP_01..10
+T_HUB_DECAL_01..06
+SPR_DOOR_DUNGEON or T_MARK_DOOR_<DUN_ID> if visually suitable
 ```
 
 ---
@@ -135,7 +141,7 @@ Use for final asset IDs:
 ```text
 SPR_PLAYER_TOPDOWN
 SPR_NPC_SAVEHOUSE
-SPR_NPC_GENERIC_01
+SPR_NPC_GENERIC_01..03
 ```
 
 Note: This pack is sheet-based, not pre-sliced into named character PNG files. The asset agent must crop final character sprites from the transparent spritesheet.
@@ -170,9 +176,7 @@ assets/selected/kenney/ui/Input Prompts Pixel 16x/
 Use for final asset IDs:
 
 ```text
-SPR_INPUT_A
-SPR_INPUT_B
-SPR_INPUT_MENU
+SPR_INTERACT_PROMPT
 ```
 
 Note: Source folder uses the Unicode `×`; repo folder uses ASCII `x` for safer paths.
@@ -207,9 +211,8 @@ Use for final asset IDs:
 
 ```text
 SPR_UI_DIALOG_FRAME
-SPR_UI_CURSOR
-SPR_UI_HEART_FULL
-SPR_UI_HEART_EMPTY
+SPR_UI_CURSOR / SPR_UI_SELECTOR
+SPR_UI_HEART
 ```
 
 ---
@@ -225,7 +228,7 @@ After staging, the asset agent must inspect images and choose a **small MakeCode
 | Hub ground/road/wall tiles | 12-24 tiles |
 | Hub props/signs/door candidates | 6-12 sprites/tiles |
 | Top-down player/NPC sprites | 3-6 cropped sprites |
-| Input prompts | 1-3 icons |
+| Input prompts | 1 icon |
 | UI elements | 2-6 sprites |
 
 ### Hard rules
@@ -235,7 +238,7 @@ After staging, the asset agent must inspect images and choose a **small MakeCode
 - Prefer transparent PNGs over magenta-background PNGs.
 - Avoid perspective mismatch: no isometric/axonometric in Batch 1.
 - Keep final files in `assets/selected/kenney/...` only after visual approval by the asset agent.
-- Update `docs/ASSET_MANIFEST.md` with final exact filenames.
+- Update `docs/ASSET_MANIFEST.md` with final exact filenames and canonical asset IDs from `.github/ASSET_REQUIREMENTS.md`.
 
 ---
 

--- a/tools/select_kenney_batch1.ps1
+++ b/tools/select_kenney_batch1.ps1
@@ -1,0 +1,90 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$KenneyRoot,
+
+    [Parameter(Mandatory=$true)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+function Copy-RequiredFile {
+    param(
+        [Parameter(Mandatory=$true)][string]$RelativeSource,
+        [Parameter(Mandatory=$true)][string]$RelativeTarget
+    )
+
+    $source = Join-Path $KenneyRoot $RelativeSource
+    $target = Join-Path $RepoRoot $RelativeTarget
+    $targetDir = Split-Path $target -Parent
+
+    if (-not (Test-Path $source)) {
+        Write-Warning "Missing source: $RelativeSource"
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+    Copy-Item -Force -Path $source -Destination $target
+    Write-Host "Copied $RelativeSource -> $RelativeTarget"
+}
+
+function Copy-RequiredFolder {
+    param(
+        [Parameter(Mandatory=$true)][string]$RelativeSourceFolder,
+        [Parameter(Mandatory=$true)][string]$RelativeTargetFolder
+    )
+
+    $source = Join-Path $KenneyRoot $RelativeSourceFolder
+    $target = Join-Path $RepoRoot $RelativeTargetFolder
+
+    if (-not (Test-Path $source)) {
+        Write-Warning "Missing source folder: $RelativeSourceFolder"
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $target | Out-Null
+    Copy-Item -Force -Recurse -Path (Join-Path $source "*") -Destination $target
+    Write-Host "Copied folder $RelativeSourceFolder -> $RelativeTargetFolder"
+}
+
+Write-Host "Kenney root: $KenneyRoot"
+Write-Host "Repo root:   $RepoRoot"
+Write-Host "Staging Batch 1 candidate pools..."
+
+# 1) RPG Urban Pack
+Copy-RequiredFile "2D assets\RPG Urban Pack\License.txt" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\License.txt"
+Copy-RequiredFile "2D assets\RPG Urban Pack\Preview.png" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\Preview.png"
+Copy-RequiredFile "2D assets\RPG Urban Pack\Sample.png" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\Sample.png"
+Copy-RequiredFolder "2D assets\RPG Urban Pack\Tilemap" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\Tilemap"
+Copy-RequiredFolder "2D assets\RPG Urban Pack\Tiles" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\Tiles"
+Copy-RequiredFolder "2D assets\RPG Urban Pack\Bonus" "assets\working\palette-tests\kenney-batch1\hub\RPG Urban Pack\Bonus"
+
+# 2) Roguelike City Pack
+Copy-RequiredFile "2D assets\Roguelike City Pack\License.txt" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\License.txt"
+Copy-RequiredFile "2D assets\Roguelike City Pack\Preview.png" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\Preview.png"
+Copy-RequiredFile "2D assets\Roguelike City Pack\Sample.png" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\Sample.png"
+Copy-RequiredFile "2D assets\Roguelike City Pack\Tilesheet.txt" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\Tilesheet.txt"
+Copy-RequiredFolder "2D assets\Roguelike City Pack\Tilemap" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\Tilemap"
+Copy-RequiredFolder "2D assets\Roguelike City Pack\Tiles" "assets\working\palette-tests\kenney-batch1\hub\Roguelike City Pack\Tiles"
+
+# 3) Roguelike Characters Pack
+Copy-RequiredFile "2D assets\Roguelike Characters Pack\License.txt" "assets\working\palette-tests\kenney-batch1\hub\Roguelike Characters Pack\License.txt"
+Copy-RequiredFile "2D assets\Roguelike Characters Pack\Preview.png" "assets\working\palette-tests\kenney-batch1\hub\Roguelike Characters Pack\Preview.png"
+Copy-RequiredFile "2D assets\Roguelike Characters Pack\Sample.png" "assets\working\palette-tests\kenney-batch1\hub\Roguelike Characters Pack\Sample.png"
+Copy-RequiredFolder "2D assets\Roguelike Characters Pack\Spritesheet" "assets\working\palette-tests\kenney-batch1\hub\Roguelike Characters Pack\Spritesheet"
+
+# 4) Input Prompts Pixel 16x. Source uses Unicode multiplication sign.
+Copy-RequiredFile "Icons\Input Prompts Pixel 16×\License.txt" "assets\working\palette-tests\kenney-batch1\ui\Input Prompts Pixel 16x\License.txt"
+Copy-RequiredFile "Icons\Input Prompts Pixel 16×\Preview.png" "assets\working\palette-tests\kenney-batch1\ui\Input Prompts Pixel 16x\Preview.png"
+Copy-RequiredFile "Icons\Input Prompts Pixel 16×\Tilesheet.txt" "assets\working\palette-tests\kenney-batch1\ui\Input Prompts Pixel 16x\Tilesheet.txt"
+Copy-RequiredFolder "Icons\Input Prompts Pixel 16×\Tilemap" "assets\working\palette-tests\kenney-batch1\ui\Input Prompts Pixel 16x\Tilemap"
+Copy-RequiredFolder "Icons\Input Prompts Pixel 16×\Tiles" "assets\working\palette-tests\kenney-batch1\ui\Input Prompts Pixel 16x\Tiles"
+
+# 5) UI Pixel Pack
+Copy-RequiredFile "UI assets\UI Pixel Pack\Instructions.txt" "assets\working\palette-tests\kenney-batch1\ui\UI Pixel Pack\Instructions.txt"
+Copy-RequiredFile "UI assets\UI Pixel Pack\License.txt" "assets\working\palette-tests\kenney-batch1\ui\UI Pixel Pack\License.txt"
+Copy-RequiredFile "UI assets\UI Pixel Pack\Preview.png" "assets\working\palette-tests\kenney-batch1\ui\UI Pixel Pack\Preview.png"
+Copy-RequiredFolder "UI assets\UI Pixel Pack\Spritesheet" "assets\working\palette-tests\kenney-batch1\ui\UI Pixel Pack\Spritesheet"
+
+Write-Host "Batch 1 staging complete."
+Write-Host "Next: visually inspect assets/working/palette-tests/kenney-batch1 and copy only final selected files to assets/selected/kenney/."


### PR DESCRIPTION
## Summary
- Adds `docs/KENNEY_ASSET_MAP.md` mapping Kenney All-in-1 package folders to NeonKiez repo target folders.
- Updates `docs/ASSET_PIPELINE.md` to point agents to the new source-of-truth mapping.
- Seeds `docs/ASSET_MANIFEST.md` with the first Hub visibility batch targets.

## Scope
- Documentation only.
- No game code or asset files changed.
- Mapping is based on the uploaded Kenney All-in-1 HTML package overview, which lists package folders rather than individual PNG/WAV filenames.

## Test Evidence
- MANUAL TEST PASSED: Documentation update only; no MakeCode runtime changes.

## Follow-up
- After the Kenney archive is available locally, copy curated files from the listed package folders into `assets/selected/kenney/...` and replace `<file>.png` placeholders in `ASSET_MANIFEST.md` with exact filenames.