### PR TITLE
fix: store hub metadata in Sprite.data

### DIFF
--- a/game_controller_hub.ts
+++ b/game_controller_hub.ts
@@ -85,17 +85,14 @@ namespace GameController {
     }
 
     function handleInteractable(s: Sprite) {
-      const hs = s as HubSprite;
-      if (hs.isDoor) {
-        // Enter dungeon
-        if (hs.dungeonId) GameController.enterDungeon(hs.dungeonId);
-      } else if (hs.isNPC) {
-        // Talk to NPC
-        if (hs.dialogId) showDialog(hs.dialogId);
+      if (s.data[HUB_SPRITE_DATA_IS_DOOR]) {
+        const dungeonId = s.data[HUB_SPRITE_DATA_DUNGEON_ID] as string;
+        if (dungeonId) GameController.enterDungeon(dungeonId);
+      } else if (s.data[HUB_SPRITE_DATA_IS_NPC]) {
+        const dialogId = s.data[HUB_SPRITE_DATA_DIALOG_ID] as string;
+        if (dialogId) showDialog(dialogId);
       }
     }
   }
 }
-
-
 

--- a/tests/hub-sprite-data.test.js
+++ b/tests/hub-sprite-data.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { readRepoFile } = require("./source-utils.js");
+
+test("hub sprites store metadata in Sprite.data", () => {
+  const worldHub = readRepoFile("world_hub.ts");
+  const hubController = readRepoFile("game_controller_hub.ts");
+
+  assert.match(worldHub, /npc\.data\[HUB_SPRITE_DATA_IS_NPC\] = true/);
+  assert.match(worldHub, /npc\.data\[HUB_SPRITE_DATA_DIALOG_ID\] = dialogId/);
+  assert.match(worldHub, /door\.data\[HUB_SPRITE_DATA_IS_DOOR\] = true/);
+  assert.match(worldHub, /door\.data\[HUB_SPRITE_DATA_DUNGEON_ID\] = dungeonId/);
+
+  assert.match(hubController, /s\.data\[HUB_SPRITE_DATA_IS_DOOR\]/);
+  assert.match(hubController, /s\.data\[HUB_SPRITE_DATA_IS_NPC\]/);
+
+  assert.doesNotMatch(worldHub, /\(npc as any\)\.(?:isNPC|dialogId)/);
+  assert.doesNotMatch(worldHub, /\(door as any\)\.(?:isDoor|dungeonId)/);
+  assert.doesNotMatch(hubController, /as HubSprite/);
+});

--- a/world_hub.ts
+++ b/world_hub.ts
@@ -8,6 +8,11 @@ const HUB_DOOR_X = 80;
 const HUB_DOOR_Y = 80;
 const HUB_FINAL_DOOR_Y = 100;
 
+const HUB_SPRITE_DATA_IS_NPC = "isNPC";
+const HUB_SPRITE_DATA_DIALOG_ID = "dialogId";
+const HUB_SPRITE_DATA_IS_DOOR = "isDoor";
+const HUB_SPRITE_DATA_DUNGEON_ID = "dungeonId";
+
 function spawnHubContent(roomRow: number, roomCol: number) {
   // Ensure sprite kinds exist before spawning hub content
   initSpriteKinds();
@@ -31,8 +36,8 @@ function spawnNPC(npcId: string, x: number, y: number, dialogId: string) {
   // KIND_NPC is guaranteed initialized (fallback at startup, upgraded on first update)
   const npc = sprites.create(imgNpc(npcId), KIND_NPC);
   npc.setPosition(x, y);
-  (npc as any).isNPC = true;
-  (npc as any).dialogId = dialogId;
+  npc.data[HUB_SPRITE_DATA_IS_NPC] = true;
+  npc.data[HUB_SPRITE_DATA_DIALOG_ID] = dialogId;
 }
 
 function spawnDungeonDoors(roomRow: number, roomCol: number) {
@@ -76,8 +81,8 @@ function spawnDungeonDoors(roomRow: number, roomCol: number) {
 function spawnDoor(dungeonId: string, x: number, y: number) {
   const door = sprites.create(imgDoor(dungeonId), KIND_DOOR);
   door.setPosition(x, y);
-  (door as any).dungeonId = dungeonId;
-  (door as any).isDoor = true;
+  door.data[HUB_SPRITE_DATA_DUNGEON_ID] = dungeonId;
+  door.data[HUB_SPRITE_DATA_IS_DOOR] = true;
 }
 
 function interactWithSavehouse() {


### PR DESCRIPTION
## Problem
The MakeCode Arcade simulator crashes on the first hub NPC spawn with:

```text
Uncaught TypeError: Cannot read properties of Sprite
at spawnNPC (world_hub.ts:30:1)
```

The player sprite is created successfully immediately before this. The failing path then assigns ad-hoc fields directly to a `Sprite` instance.

## Slice
- Store NPC and door metadata through MakeCode's built-in `Sprite.data` object.
- Read the same keys during hub interaction handling.
- Add a focused source-contract test that rejects direct ad-hoc hub fields.

## Non-goals
- No SpriteKind redesign.
- No tilemap, asset, gameplay, or interaction-distance changes.
- No changes to the separate meta-node sprite path.

## Evidence
- MakeCode's `Sprite` implementation exposes a lazily initialized `data` object for custom metadata.
- Microsoft's `arcade-sprite-data` extension uses that same object.
- Existing player creation succeeds; only the NPC-specific post-create metadata path differs.

## Manual validation required
Start the MakeCode Simulator and verify that the center hub loads past `spawnNPC`, with the NPC visible and interaction still resolving its dialog ID.